### PR TITLE
using target blank for social links in nav

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,31 @@
+{% import "macros/macros.html" as post_macros %}
+
+<!DOCTYPE html>
+<html lang="en">
+<html class="dark light">
+
+{% include "partials/header.html" %}
+
+<body>
+    <div class="content">
+        {% include "partials/nav.html" %}
+
+        {# Post page is the default #}
+        {% block main_content %}
+            Nothing here?!
+        {% endblock main_content %}
+
+        {% if page.extra.comment is defined  %}
+            {% set show_comment = page.extra.comment %}
+        {% else %}
+            {% set show_comment = false %}
+        {% endif %}
+
+        {% if show_comment %}
+        <div class="giscus"></div>
+        {% include "_giscus_script.html" %}
+        {% endif %}
+    </div>
+</body>
+
+</html>

--- a/templates/partials/nav.html
+++ b/templates/partials/nav.html
@@ -1,0 +1,33 @@
+<header>
+    <div class="main">
+        <a href={{ config.base_url }}>{{ config.title }}</a>
+
+        <div class="socials">
+            {% for social in config.extra.socials | default(value=[]) %}
+            {% if social.target %}
+                <a rel="me" href="{{ social.url }}" target="{{social.target}}" class="social">
+            {% else %}
+            <a rel="me" href="{{ social.url }}" target="_blank" class="social">
+            {% endif %}
+                <img alt={{ social.name }} src={{ get_url(path="social_icons/" ~ social.icon ~ ".svg") }}>
+            </a>
+            {% endfor %}
+        </div>
+    </div>
+
+    <nav>
+        {% for menu in config.extra.menu | default(value=[]) %}
+        <a href={{ get_url(path=menu.url) }} style="margin-left: 0.5em">{{ menu.name }}</a>
+        {% endfor %}
+
+        {% if config.extra.theme | default(value="toggle") == "toggle" %}
+        |<a id="dark-mode-toggle" onclick="toggleTheme(); event.preventDefault();" href="#">
+            <img src={{ get_url(path="feather/sun.svg") }} id="sun-icon" style="filter: invert(1);" alt="Light" />
+            <img src={{ get_url(path="feather/moon.svg") }} id="moon-icon" alt="Dark" />
+        </a>
+
+        <!-- Inititialize the theme toggle icons -->
+        <script>updateItemToggleTheme()</script>
+        {% endif %}
+    </nav>
+</header>


### PR DESCRIPTION
- allowing to configure target prop of social links from config.toml
- using `target="_blank"` as a default value of social links